### PR TITLE
feat: 상태관리 라이브러리 추가 및 Prettier 설정

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 4,
+  "singleQuote": true,
+  "printWidth": 80
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cyworld-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "jotai": "^2.12.5",
         "next": "15.4.3",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -1311,7 +1312,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2385,7 +2386,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4101,6 +4102,27 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.12.5",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.12.5.tgz",
+      "integrity": "sha512-G8m32HW3lSmcz/4mbqx0hgJIQ0ekndKWiYP7kWVKi0p6saLXdSoye+FZiOFyonnd7Q482LCzm8sMDl7Ar1NWDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "jotai": "^2.12.5",
+    "next": "15.4.3",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.3"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.4.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## 변경사항
1. 상태관리 라이브러리 Jotai 추가
- 사용 방법 (예시)

    1. 외부 파일(ts)에 Store 생성
    ```ts
    //src/app/store/userStore.ts
    
    interface UserStore {
        id: number,
        name: string,
        accessToken?: string,
        refreshToken?: string
    }

    export const userStore = atom<UserStore | null>(null)
    ```
    2. 사용해야 하는 컴포넌트에서 import하여 사용
    ```tsx
    //src/app/components/Component.tsx
    "use client";

    export default function Component() {
        const [user, setUser] = useAtom(userStore);

        return <div>{user?.name}</div>
    }
    ```
- 사용 가능한 함수
    - useAtom: useState와 동일. 대신 store는 전역적이고 useState는 지역적임.
    - useAtomValue: useState의 첫 번째 인자, value만 참조하고 싶을 때 사용.
    - useSetAtom: useState의 두 번째 인자, setter만 참조하고 싶을 때 사용.

2. Prettier 설정 추가
- VSCode 사용 시 Prettier 확장을 설치하면 .prettierrc에 선언되어 있는 코드 포맷팅 컨벤션을 자동으로 따라감.

## 고려해야 할 점
- tabWidth: 2로 바꾸기 고려